### PR TITLE
fix_translations_in_getValue_method

### DIFF
--- a/manuscript/01-Block-Bindings.md
+++ b/manuscript/01-Block-Bindings.md
@@ -74,12 +74,12 @@ function getValue(condition) {
         return value;
     } else {
 
-        // value doesn't exist here
+        // змінна value не буде існувати в цьому блоці
 
         return null;
     }
 
-    // value doesn't exist here
+    // змінна value не буде існувати в цьому блоці
 }
 ```
 


### PR DESCRIPTION
Переклад коментарів в функції getValue() з використанням конструкції let